### PR TITLE
[CP-1837] Random crashes while copying files

### DIFF
--- a/taglib/CMakeLists.txt
+++ b/taglib/CMakeLists.txt
@@ -37,6 +37,7 @@ set(tag_HDRS
   tag.h
   fileref.h
   audioproperties.h
+  configuration.h
   taglib_export.h
   ${CMAKE_CURRENT_BINARY_DIR}/../taglib_config.h
   toolkit/taglib.h

--- a/taglib/configuration.h
+++ b/taglib/configuration.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    copyright            : (C) 2023 Mudita sp. z o.o.
+ ***************************************************************************/
+
+/***************************************************************************
+ *   This library is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU Lesser General Public License version   *
+ *   2.1 as published by the Free Software Foundation.                     *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful, but   *
+ *   WITHOUT ANY WARRANTY; without even the implied warranty of            *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this library; if not, write to the Free Software   *
+ *   Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA         *
+ *   02110-1301  USA                                                       *
+ *                                                                         *
+ *   Alternatively, this file is available under the Mozilla Public        *
+ *   License Version 1.1.  You may obtain a copy of the License at         *
+ *   http://www.mozilla.org/MPL/                                           *
+ ***************************************************************************/
+
+#ifndef TAGLIB_CONFIGURATION_H
+#define TAGLIB_CONFIGURATION_H
+
+#include <limits>
+
+namespace TagLib {
+
+  struct Configuration
+  {
+    Configuration() :
+      readOnly(false), limitMemoryUsage(false), maxTagSize(std::numeric_limits<std::size_t>::max())
+    {}
+
+    explicit Configuration(bool readOnly) :
+      readOnly(readOnly), limitMemoryUsage(false), maxTagSize(std::numeric_limits<std::size_t>::max())
+    {}
+
+    Configuration(bool readOnly, bool limitMemoryUsage, std::size_t maxTagSize) :
+      readOnly(readOnly), limitMemoryUsage(limitMemoryUsage), maxTagSize(maxTagSize)
+    {}
+
+    const bool readOnly;
+    const bool limitMemoryUsage;
+    const std::size_t maxTagSize;
+  };
+
+} // namespace TagLib
+
+#endif

--- a/taglib/fileref.h
+++ b/taglib/fileref.h
@@ -31,6 +31,7 @@
 
 #include "taglib_export.h"
 #include "audioproperties.h"
+#include "configuration.h"
 
 namespace TagLib {
 
@@ -288,11 +289,11 @@ namespace TagLib {
     explicit FileRef(FileName fileName,
                      bool readAudioProperties,
                      AudioProperties::ReadStyle audioPropertiesStyle,
-                     bool readOnly);
+                     Configuration configuration);
 
   private:
-    void parse(FileName fileName, bool readAudioProperties, AudioProperties::ReadStyle audioPropertiesStyle, bool readOnly);
-    void parse(IOStream *stream, bool readAudioProperties, AudioProperties::ReadStyle audioPropertiesStyle);
+    void parse(FileName fileName, bool readAudioProperties, AudioProperties::ReadStyle audioPropertiesStyle, Configuration configuration = Configuration());
+    void parse(IOStream *stream, bool readAudioProperties, AudioProperties::ReadStyle audioPropertiesStyle, Configuration configuration = Configuration());
 
     class FileRefPrivate;
     FileRefPrivate *d;
@@ -305,8 +306,16 @@ namespace TagLib {
   class ConstFileRef : public FileRef{
   public:
     explicit ConstFileRef(FileName fileName,
-                             bool readAudioProperties = true,
-                             AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
+                          bool readAudioProperties = true,
+                          AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
+  };
+
+  class ConstMemoryConstrainedFileRef : public FileRef{
+  public:
+    explicit ConstMemoryConstrainedFileRef(FileName fileName,
+                                           std::size_t maxTagSize,
+                                           bool readAudioProperties = true,
+                                           AudioProperties::ReadStyle audioPropertiesStyle = AudioProperties::Average);
   };
 
 } // namespace TagLib

--- a/taglib/flac/flacfile.h
+++ b/taglib/flac/flacfile.h
@@ -33,6 +33,7 @@
 
 #include "flacpicture.h"
 #include "flacproperties.h"
+#include "configuration.h"
 
 namespace TagLib {
 
@@ -124,7 +125,8 @@ namespace TagLib {
       // BIC: merge with the above constructor
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           Configuration configuration = Configuration());
 
       /*!
        * Destroys this instance of the File.
@@ -331,8 +333,8 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties);
-      void scan();
+      void read(bool readProperties, Configuration configuration = Configuration());
+      void scan(Configuration configuration = Configuration());
 
       class FilePrivate;
       FilePrivate *d;

--- a/taglib/mpeg/id3v2/id3v2tag.h
+++ b/taglib/mpeg/id3v2/id3v2tag.h
@@ -36,6 +36,8 @@
 #include "id3v2.h"
 #include "id3v2framefactory.h"
 
+#include "configuration.h"
+
 namespace TagLib {
 
   class File;
@@ -147,7 +149,8 @@ namespace TagLib {
        * \see FrameFactory
        */
       Tag(File *file, long tagOffset,
-          const FrameFactory *factory = FrameFactory::instance());
+          const FrameFactory *factory = FrameFactory::instance(),
+          Configuration configuration = Configuration());
 
       /*!
        * Destroys this Tag instance.
@@ -378,7 +381,7 @@ namespace TagLib {
        * the Header, the body of the tag  (which contains the ExtendedHeader and
        * frames) and Footer.
        */
-      void read();
+      void read(Configuration configuration);
 
       /*!
        * This is called by read to parse the body of the tag.  It determines if an

--- a/taglib/mpeg/mpegfile.cpp
+++ b/taglib/mpeg/mpegfile.cpp
@@ -150,12 +150,13 @@ MPEG::File::File(FileName file, ID3v2::FrameFactory *frameFactory,
 }
 
 MPEG::File::File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
-                 bool readProperties, Properties::ReadStyle) :
+                 bool readProperties, Properties::ReadStyle,
+                 Configuration configuration) :
   TagLib::File(stream),
   d(new FilePrivate(frameFactory))
 {
   if(isOpen())
-    read(readProperties);
+    read(readProperties, configuration);
 }
 
 MPEG::File::~File()
@@ -498,14 +499,14 @@ bool MPEG::File::hasAPETag() const
 // private members
 ////////////////////////////////////////////////////////////////////////////////
 
-void MPEG::File::read(bool readProperties)
+void MPEG::File::read(bool readProperties, Configuration configuration)
 {
   // Look for an ID3v2 tag
 
   d->ID3v2Location = findID3v2();
 
   if(d->ID3v2Location >= 0) {
-    d->tag.set(ID3v2Index, new ID3v2::Tag(this, d->ID3v2Location, d->ID3v2FrameFactory));
+    d->tag.set(ID3v2Index, new ID3v2::Tag(this, d->ID3v2Location, d->ID3v2FrameFactory, configuration));
     d->ID3v2OriginalSize = ID3v2Tag()->header()->completeTagSize();
   }
 

--- a/taglib/mpeg/mpegfile.h
+++ b/taglib/mpeg/mpegfile.h
@@ -34,6 +34,8 @@
 
 #include "id3v2.h"
 
+#include "configuration.h"
+
 namespace TagLib {
 
   namespace ID3v2 { class Tag; class FrameFactory; }
@@ -112,7 +114,8 @@ namespace TagLib {
        */
       File(IOStream *stream, ID3v2::FrameFactory *frameFactory,
            bool readProperties = true,
-           Properties::ReadStyle propertiesStyle = Properties::Average);
+           Properties::ReadStyle propertiesStyle = Properties::Average,
+           Configuration configuration = Configuration());
 
       /*!
        * Destroys this instance of the File.
@@ -375,7 +378,7 @@ namespace TagLib {
       File(const File &);
       File &operator=(const File &);
 
-      void read(bool readProperties);
+      void read(bool readProperties, Configuration configuration = Configuration());
       long findID3v2();
 
       class FilePrivate;


### PR DESCRIPTION
Skip reading too large header to ensure the system works correctly and is stable.
On Harmony reading too large a block from the header caused system crashes.
Crashes occurred while copying files on the device.